### PR TITLE
Use Secret Manager for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,16 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 export SPREADSHEET_ID=<your sheet id>
+# Optional: use a local credentials file
 export GOOGLE_APPLICATION_CREDENTIALS=credentials.json
+# Or fetch credentials from Secret Manager
+export GOOGLE_CLIENT_SECRET_NAME=projects/693032250063/secrets/webapp_google_client_secret
 python main.py
+```
+Make sure you have authenticated with the Google Cloud SDK so the
+application can access Secret Manager locally:
+```bash
+gcloud auth application-default login
 ```
 
 ## Deploying to Cloud Run

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=2.3
 gunicorn
 google-api-python-client
 google-auth
+google-cloud-secret-manager

--- a/services/google_sheets.py
+++ b/services/google_sheets.py
@@ -1,18 +1,47 @@
 import os
+import json
+from functools import lru_cache
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from google.cloud import secretmanager
 
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
 SPREADSHEET_ID = os.environ.get('SPREADSHEET_ID')
-SERVICE_ACCOUNT_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', 'credentials.json')
+SERVICE_ACCOUNT_FILE = os.environ.get(
+    'GOOGLE_APPLICATION_CREDENTIALS', 'credentials.json'
+)
+SECRET_NAME = os.environ.get(
+    'GOOGLE_CLIENT_SECRET_NAME',
+    'projects/693032250063/secrets/webapp_google_client_secret',
+)
 
 
-def _get_sheet():
-    credentials = service_account.Credentials.from_service_account_file(
+@lru_cache()
+def _load_credentials():
+    """Load service account credentials.
+
+    Credentials are fetched from Secret Manager if ``SECRET_NAME`` is
+    configured, otherwise they are read from ``SERVICE_ACCOUNT_FILE``.
+    """
+    if SECRET_NAME:
+        client = secretmanager.SecretManagerServiceClient()
+        name = f"{SECRET_NAME}/versions/latest"
+        response = client.access_secret_version(name=name)
+        info = json.loads(response.payload.data.decode("UTF-8"))
+        return service_account.Credentials.from_service_account_info(
+            info, scopes=SCOPES
+        )
+
+    return service_account.Credentials.from_service_account_file(
         SERVICE_ACCOUNT_FILE, scopes=SCOPES
     )
-    service = build('sheets', 'v4', credentials=credentials)
+
+
+@lru_cache()
+def _get_sheet():
+    credentials = _load_credentials()
+    service = build("sheets", "v4", credentials=credentials)
     return service.spreadsheets()
 
 


### PR DESCRIPTION
## Summary
- load service account credentials from GCP Secret Manager
- cache credentials and Sheet service client
- add google-cloud-secret-manager dependency
- document how to use Secret Manager when running locally

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e3b4e6718832d91ef60d7e730be0f