### PR TITLE
Add OAuth proxy routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,24 @@ The service account retrieved from Secret Manager must have edit access to the
 target spreadsheet. Share the spreadsheet with the service account's email
 address. The spreadsheet should contain two sheets named `bank_input` and
 `orders`, which are used when appending data from the API.
+
+## OAuth proxy setup
+
+The service also exposes two helper endpoints for OAuth 2.0 flows used by
+Custom GPT Actions:
+
+* `/oauth2/auth` – redirects the user to Google's consent screen.
+* `/oauth2/token` – exchanges the authorization code for an access token.
+
+Set the following environment variables when deploying to Cloud Run so the
+proxy can call Google's OAuth endpoints:
+
+```bash
+export GOOGLE_OAUTH_CLIENT_ID=<your-client-id>
+export GOOGLE_OAUTH_CLIENT_SECRET=<your-client-secret>
+export OAUTH_REDIRECT_URI=<OpenAI-callback-URL>
+```
+
+`OAUTH_REDIRECT_URI` should match the callback URL provided by the GPT Builder.
+All three URLs (your API host, Authorization URL and Token URL) will then share
+the same `*.run.app` domain, satisfying the builder's domain requirement.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,9 @@ def create_app():
     app = Flask(__name__)
 
     from .routes.invoice import invoice_bp
+    from .routes.oauth import oauth_bp
+
     app.register_blueprint(invoice_bp, url_prefix="/log-invoice")
+    app.register_blueprint(oauth_bp)
 
     return app

--- a/app/routes/oauth.py
+++ b/app/routes/oauth.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, request, redirect, jsonify
+import requests
+import os
+
+oauth_bp = Blueprint('oauth', __name__)
+
+CLIENT_ID = os.environ['GOOGLE_OAUTH_CLIENT_ID']
+CLIENT_SECRET = os.environ['GOOGLE_OAUTH_CLIENT_SECRET']
+REDIRECT_URI = os.environ['OAUTH_REDIRECT_URI']
+
+@oauth_bp.route('/oauth2/auth')
+def oauth_authorize():
+    google_auth_url = (
+        'https://accounts.google.com/o/oauth2/v2/auth'
+        '?response_type=code'
+        f'&client_id={CLIENT_ID}'
+        f'&redirect_uri={REDIRECT_URI}'
+        '&scope=https://www.googleapis.com/auth/spreadsheets'
+    )
+    return redirect(google_auth_url)
+
+@oauth_bp.route('/oauth2/token', methods=['POST'])
+def oauth_token():
+    code = request.form.get('code')
+    token_resp = requests.post('https://oauth2.googleapis.com/token', data={
+        'code': code,
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET,
+        'redirect_uri': REDIRECT_URI,
+        'grant_type': 'authorization_code'
+    })
+    return jsonify(token_resp.json()), token_resp.status_code

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 google-api-python-client
 google-auth
 google-cloud-secret-manager
+requests


### PR DESCRIPTION
## Summary
- add `/oauth2/auth` and `/oauth2/token` endpoints to proxy Google OAuth
- register new blueprint in the Flask app
- document OAuth proxy environment variables
- include `requests` dependency

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68629846bddc832daf62b4b5b38a889d